### PR TITLE
SPEECHPLAN-17 Renovate: Abstraktion-des-Firestore-Interfaces

### DIFF
--- a/app/src/main/java/de/geosphere/speechplaning/MainActivity.kt
+++ b/app/src/main/java/de/geosphere/speechplaning/MainActivity.kt
@@ -83,6 +83,7 @@ class MainActivity :
                 districtRepository.save(it)
             }
         }
+
         val speechRepository: SpeechRepository by inject()
         val test2 = MockedListOfDummyClasses.speechesMockupList
         test2.forEach {
@@ -94,8 +95,6 @@ class MainActivity :
 
         setContent {
             val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
-
-
 
             SpeechPlaningTheme {
                 val navController = rememberNavController()

--- a/app/src/main/java/de/geosphere/speechplaning/data/model/CongregationEvent.kt
+++ b/app/src/main/java/de/geosphere/speechplaning/data/model/CongregationEvent.kt
@@ -1,6 +1,7 @@
 package de.geosphere.speechplaning.data.model
 
 import com.google.firebase.firestore.DocumentId
+import de.geosphere.speechplaning.data.Event
 import java.time.LocalDate // Using java.time.LocalDate as discussed
 
 /**
@@ -19,22 +20,10 @@ data class CongregationEvent(
     @DocumentId val id: String = "",
     val congregationId: String = "",
     val date: LocalDate,
-    val eventType: EventType,
+    val eventType: Event,
     val speechId: String? = null,
     val speakerId: String? = null,
     val chairmanId: String? = null,
     val notes: String? = null
 ) : SavableDataClass() // Assuming SavableDataClass is a suitable base class
 
-/**
- * Defines the type of a congregational event.
- */
-enum class EventType {
-    PUBLIC_TALK,
-    WATCHTOWER_STUDY,
-    MEMORIAL,
-    SPECIAL_EVENT,
-    CONVENTION, // Added based on potential need
-    CIRCUIT_ASSEMBLY, // Added based on potential need
-    OTHER // For any other type of event
-}

--- a/app/src/main/java/de/geosphere/speechplaning/data/repository/base/FirestoreSubcollectionRepository.kt
+++ b/app/src/main/java/de/geosphere/speechplaning/data/repository/base/FirestoreSubcollectionRepository.kt
@@ -1,0 +1,40 @@
+package de.geosphere.speechplaning.data.repository.base
+
+/**
+ * Generisches Interface für Firestore-Repositories, die auf Subcollections operieren.
+ * @param T Der Typ der Entität in der Subcollection.
+ * @param PID Der Typ der IDs der übergeordneten Dokumente. Oftmals String.
+ *             (Die ID der Entität selbst ist hier implizit als String angenommen,
+ *              basierend auf BaseFirestoreRepository, könnte aber auch generisch sein)
+ */
+interface FirestoreSubcollectionRepository<T : Any, PID : Any> { // Angenommen, Entitäts-ID bleibt String
+    /**
+     * Speichert eine Entität in einer Subcollection.
+     * @param entity Die zu speichernde Entität.
+     * @param parentIds Die IDs der übergeordneten Dokumente, die den Pfad zur Subcollection definieren.
+     * @return Die ID der gespeicherten oder aktualisierten Entität.
+     */
+    suspend fun save(entity: T, vararg parentIds: PID): String // Entitäts-ID als String
+
+    /**
+     * Ruft eine Entität anhand ihrer ID aus einer Subcollection ab.
+     * @param id Die ID der abzurufenden Entität.
+     * @param parentIds Die IDs der übergeordneten Dokumente.
+     * @return Die Entität oder null, wenn nicht gefunden.
+     */
+    suspend fun getById(id: String, vararg parentIds: PID): T?
+
+    /**
+     * Ruft alle Entitäten aus einer Subcollection ab.
+     * @param parentIds Die IDs der übergeordneten Dokumente.
+     * @return Eine Liste aller Entitäten.
+     */
+    suspend fun getAll(vararg parentIds: PID): List<T>
+
+    /**
+     * Löscht eine Entität anhand ihrer ID aus einer Subcollection.
+     * @param id Die ID der zu löschenden Entität.
+     * @param parentIds Die IDs der übergeordneten Dokumente.
+     */
+    suspend fun delete(id: String, vararg parentIds: PID)
+}

--- a/app/src/main/java/de/geosphere/speechplaning/di/ApplicationModule.kt
+++ b/app/src/main/java/de/geosphere/speechplaning/di/ApplicationModule.kt
@@ -7,6 +7,7 @@ import de.geosphere.speechplaning.data.repository.CongregationEventRepository
 import de.geosphere.speechplaning.data.repository.CongregationRepository
 import de.geosphere.speechplaning.data.repository.DistrictRepository
 import de.geosphere.speechplaning.data.repository.SpeakerRepository
+import de.geosphere.speechplaning.data.repository.SpeechRepository
 import de.geosphere.speechplaning.data.services.FirestoreService
 import de.geosphere.speechplaning.data.services.FirestoreServiceImpl
 import org.koin.android.ext.koin.androidContext
@@ -21,6 +22,7 @@ val appModule =
 
         // Repositories
         single { DistrictRepository(get()) }
+        single { SpeechRepository(get()) }
         single { CongregationRepository(get()) }
         single { SpeakerRepository(get()) }
         single { CongregationEventRepository(get()) }

--- a/app/src/test/java/de/geosphere/speechplaning/data/repository/CongregationEventRepositoryTest.kt
+++ b/app/src/test/java/de/geosphere/speechplaning/data/repository/CongregationEventRepositoryTest.kt
@@ -1,7 +1,7 @@
 package de.geosphere.speechplaning.data.repository
 
+import de.geosphere.speechplaning.data.Event
 import de.geosphere.speechplaning.data.model.CongregationEvent
-import de.geosphere.speechplaning.data.model.EventType
 import de.geosphere.speechplaning.data.services.FirestoreService
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -43,7 +43,7 @@ internal class CongregationEventRepositoryTest {
             id = testEventId,
             congregationId = testCongregationId,
             date = LocalDate.now(),
-            eventType = EventType.PUBLIC_TALK,
+            eventType = Event.MEMORIAL,
             speechId = "speechXYZ",
             speakerId = "speakerABC",
             chairmanId = "chairman123",
@@ -54,7 +54,7 @@ internal class CongregationEventRepositoryTest {
             id = "",
             congregationId = testCongregationId,
             date = LocalDate.now().plusDays(7),
-            eventType = EventType.WATCHTOWER_STUDY,
+            eventType = Event.MEMORIAL,
             notes = "Notizen für ein brandneues Event"
         )
     }


### PR DESCRIPTION
refactor: decouple enums from android context, introduce mappers, update string resources, and enhance tests for localization and coverage