### PR TITLE
CHORE: Putzerfisch MainActivity.kt - refactor: restructure main UI in…

### DIFF
--- a/app/src/main/java/de/geosphere/speechplaning/MainActivity.kt
+++ b/app/src/main/java/de/geosphere/speechplaning/MainActivity.kt
@@ -1,263 +1,46 @@
 package de.geosphere.speechplaning
 
 import android.os.Bundle
-import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.ListAlt
-import androidx.compose.material.icons.automirrored.outlined.ListAlt
-import androidx.compose.material.icons.filled.CalendarMonth
-import androidx.compose.material.icons.filled.FolderShared
-import androidx.compose.material.icons.filled.Menu
-import androidx.compose.material.icons.outlined.CalendarMonth
-import androidx.compose.material.icons.outlined.FolderShared
-import androidx.compose.material3.Badge
-import androidx.compose.material3.BadgedBox
-import androidx.compose.material3.CenterAlignedTopAppBar
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.NavigationBar
-import androidx.compose.material3.NavigationBarItem
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
-import androidx.compose.material3.TopAppBarScrollBehavior
-import androidx.compose.material3.rememberTopAppBarState
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.lifecycle.lifecycleScope
-import androidx.navigation.NavDestination
-import androidx.navigation.NavDestination.Companion.hierarchy
-import androidx.navigation.NavGraph.Companion.findStartDestination
-import androidx.navigation.NavHostController
-import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
-import androidx.navigation.compose.currentBackStackEntryAsState
-import androidx.navigation.compose.rememberNavController
-import de.geosphere.speechplaning.data.repository.DistrictRepository
-import de.geosphere.speechplaning.data.repository.SpeechRepository
-import de.geosphere.speechplaning.mockup.MockedListOfDummyClasses
-import de.geosphere.speechplaning.ui.theme.SpeechPlaningTheme
-import kotlinx.coroutines.launch
-import kotlinx.serialization.Serializable
+import de.geosphere.speechplaning.mockup.BuildDummyDBConnection
+import de.geosphere.speechplaning.ui.main.MainScreenComponent
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
+import org.koin.core.parameter.parametersOf
 
 @Suppress("UnusedPrivateProperty")
 class MainActivity :
     ComponentActivity(),
     KoinComponent {
-    @Suppress("LongMethod")
-    @OptIn(ExperimentalMaterial3Api::class)
+
+    private val dummyDbBuilder: BuildDummyDBConnection by inject {
+        parametersOf(lifecycleScope)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
-        val insetsController = WindowCompat.getInsetsController(window, window.decorView)
-        insetsController.apply {
-            hide(WindowInsetsCompat.Type.statusBars())
-            hide(WindowInsetsCompat.Type.navigationBars())
-            systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-        }
+        // enableEdgeToEdge()
+        // Das Ausblenden der Systemleisten kann auch in eine Extension-Function ausgelagert werden
 
-        val districtRepository: DistrictRepository by inject()
-        val test = MockedListOfDummyClasses.districtMockupList
-        test.forEach {
-            Log.i("Werner", "onCreate: $it")
-            lifecycleScope.launch {
-                districtRepository.save(it)
-            }
-        }
+        WindowCompat.getInsetsController(window, window.decorView).hidestSystemBars()
 
-        val speechRepository: SpeechRepository by inject()
-        val test2 = MockedListOfDummyClasses.speechesMockupList
-        test2.forEach {
-            Log.i("Werner", "onCreate: $it")
-            lifecycleScope.launch {
-                speechRepository.save(it)
-            }
-        }
+        // /////
+        dummyDbBuilder()
+        // /////
 
         setContent {
-            val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
-
-            SpeechPlaningTheme {
-                val navController = rememberNavController()
-                val navBackStackEntry by navController.currentBackStackEntryAsState()
-                val currentDestination = navBackStackEntry?.destination
-                var selectedItemIndex by rememberSaveable { mutableIntStateOf(0) }
-
-                Scaffold(
-                    topBar = {
-                        TopBarComponents(scrollBehavior)
-                    },
-                    content = { innerPadding ->
-                        NavHost(
-                            navController = navController,
-                            startDestination = BottomNavigationItem.tabs.first().route,
-                            modifier = Modifier
-                                .padding(5.dp)
-                                .padding(innerPadding)
-                        ) {
-                            composable<Screen.PlaningRoute> {
-                                HorizontalDivider()
-                            }
-                            composable<Screen.SpeakerRoute> {
-                                HorizontalDivider()
-                            }
-                            composable<Screen.SpeechesRoute> {
-                                HorizontalDivider()
-                            }
-                        }
-                    },
-
-                    bottomBar = {
-                        BottomBarComponents(currentDestination, selectedItemIndex, navController)
-                    },
-                )
-            }
-        }
-    }
-
-    @Composable
-    @OptIn(ExperimentalMaterial3Api::class)
-    private fun TopBarComponents(scrollBehavior: TopAppBarScrollBehavior) {
-        CenterAlignedTopAppBar(
-            colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
-                containerColor = MaterialTheme.colorScheme.primaryContainer,
-                titleContentColor = MaterialTheme.colorScheme.primary,
-            ),
-            title = {
-                Text(
-                    "Centered Top App Bar",
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
-                )
-            },
-            actions = {
-                IconButton(onClick = { /* do something */ }) {
-                    Icon(
-                        imageVector = Icons.Filled.Menu,
-                        contentDescription = "Localized description"
-                    )
-                }
-            },
-            scrollBehavior = scrollBehavior,
-        )
-    }
-
-    @Composable
-    private fun BottomBarComponents(
-        currentDestination: NavDestination?,
-        selectedItemIndex: Int,
-        navController: NavHostController
-    ) {
-        var selectedItemIndex1 = selectedItemIndex
-        NavigationBar {
-            BottomNavigationItem.tabs.forEachIndexed { index, navItems ->
-                NavigationBarItem(
-                    selected = currentDestination?.hierarchy?.any {
-                        it.route == navItems.route::class.qualifiedName
-                    } == true,
-                    onClick = {
-                        selectedItemIndex1 = index
-                        navController.navigate(navItems.route) {
-                            popUpTo(navController.graph.findStartDestination().id) {
-                                saveState = true
-                            }
-                            launchSingleTop = true
-                            restoreState = true
-                        }
-                        navController.navigate(navItems.route)
-                    },
-                    label = { Text(navItems.label) },
-                    icon = {
-                        BadgedBox(
-                            badge = {
-                                if (navItems.badgeCount != null) {
-                                    Badge {
-                                        Text(text = navItems.badgeCount.toString())
-                                    }
-                                } else if (navItems.hasNews) {
-                                    Badge()
-                                }
-                            }
-                        ) {
-                            Icon(
-                                imageVector = if (selectedItemIndex1 == index) {
-                                    navItems.selectedIcon
-                                } else {
-                                    navItems.unselectedIcon
-                                },
-                                contentDescription = navItems.label
-                            )
-                        }
-                    }
-                )
-            }
+            MainScreenComponent()
         }
     }
 }
 
-@Serializable
-private sealed class Screen {
-    @Serializable
-    data object SpeakerRoute : Screen()
-
-    @Serializable
-    data object PlaningRoute : Screen()
-
-    @Serializable
-    data object SpeechesRoute : Screen()
-}
-
-private data class BottomNavigationItem(
-    val label: String,
-    val selectedIcon: ImageVector,
-    val unselectedIcon: ImageVector,
-    val hasNews: Boolean,
-    val route: Screen,
-    val badgeCount: Int? = null,
-) {
-    companion object {
-        val tabs = listOf(
-            BottomNavigationItem(
-                label = "Plan",
-                selectedIcon = Icons.Filled.CalendarMonth,
-                unselectedIcon = Icons.Outlined.CalendarMonth,
-                route = Screen.PlaningRoute,
-                hasNews = true,
-            ),
-            BottomNavigationItem(
-                label = "Speakers",
-                selectedIcon = Icons.Filled.FolderShared,
-                unselectedIcon = Icons.Outlined.FolderShared,
-                route = Screen.SpeakerRoute,
-                hasNews = false,
-            ),
-            BottomNavigationItem(
-                label = "Speeches",
-                selectedIcon = Icons.AutoMirrored.Filled.ListAlt,
-                unselectedIcon = Icons.AutoMirrored.Outlined.ListAlt,
-                hasNews = false,
-                route = Screen.SpeechesRoute,
-                badgeCount = 45
-            ),
-        )
-    }
+private fun WindowInsetsControllerCompat.hidestSystemBars() {
+    hide(WindowInsetsCompat.Type.statusBars())
+    hide(WindowInsetsCompat.Type.navigationBars())
+    systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
 }

--- a/app/src/main/java/de/geosphere/speechplaning/di/ApplicationModule.kt
+++ b/app/src/main/java/de/geosphere/speechplaning/di/ApplicationModule.kt
@@ -1,5 +1,6 @@
 package de.geosphere.speechplaning.di
 
+import androidx.lifecycle.LifecycleCoroutineScope
 import com.google.firebase.firestore.FirebaseFirestore
 import de.geosphere.speechplaning.data.EventMapper
 import de.geosphere.speechplaning.data.SpiritualStatusMapper
@@ -10,6 +11,7 @@ import de.geosphere.speechplaning.data.repository.SpeakerRepository
 import de.geosphere.speechplaning.data.repository.SpeechRepository
 import de.geosphere.speechplaning.data.services.FirestoreService
 import de.geosphere.speechplaning.data.services.FirestoreServiceImpl
+import de.geosphere.speechplaning.mockup.BuildDummyDBConnection
 import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.module
 
@@ -29,6 +31,8 @@ val appModule =
 
         single { SpiritualStatusMapper(androidContext()) }
         single { EventMapper(androidContext()) }
+
+        factory { (scope: LifecycleCoroutineScope) -> BuildDummyDBConnection(scope) }
 
         // Use Cases Speech
 

--- a/app/src/main/java/de/geosphere/speechplaning/mockup/BuildDummyDBConnection.kt
+++ b/app/src/main/java/de/geosphere/speechplaning/mockup/BuildDummyDBConnection.kt
@@ -1,0 +1,43 @@
+package de.geosphere.speechplaning.mockup
+
+import android.util.Log
+import androidx.lifecycle.LifecycleCoroutineScope
+import de.geosphere.speechplaning.data.repository.DistrictRepository
+import de.geosphere.speechplaning.data.repository.SpeechRepository
+import kotlinx.coroutines.launch
+import org.koin.core.component.KoinComponent
+import org.koin.core.component.inject
+
+/**
+ * Build dummy d b connection.
+ *
+ * @property districtRepository
+ * @property speechRepository
+ * @property lifecycleScope
+ * @constructor Create empty Build dummy d b connection
+ */
+class BuildDummyDBConnection(
+    val lifecycleScope: LifecycleCoroutineScope
+): KoinComponent {
+    // Abhängigkeiten direkt hier injizieren
+    private val districtRepository: DistrictRepository by inject()
+    private val speechRepository: SpeechRepository by inject()
+
+    operator fun invoke() {
+        val test = MockedListOfDummyClasses.districtMockupList.toList()
+        test.forEach {
+            Log.i("Werner", "onCreate: $it")
+            lifecycleScope.launch {
+                districtRepository.save(it)
+            }
+        }
+
+        val test2 = MockedListOfDummyClasses.speechesMockupList.toList()
+        test2.forEach {
+            Log.i("Werner", "onCreate: $it")
+            lifecycleScope.launch {
+                speechRepository.save(it)
+            }
+        }
+    }
+}

--- a/app/src/main/java/de/geosphere/speechplaning/ui/main/AppNavHostComponent.kt
+++ b/app/src/main/java/de/geosphere/speechplaning/ui/main/AppNavHostComponent.kt
@@ -1,0 +1,36 @@
+package de.geosphere.speechplaning.ui.main
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import de.geosphere.speechplaning.ui.navigation.Screen
+
+@Composable
+fun AppNavHostComponent(
+    navController: NavHostController,
+    innerPadding: PaddingValues
+) {
+    NavHost(
+        navController = navController,
+        startDestination = BottomNavigationItem.Companion.tabs.first().route,
+        modifier = Modifier.Companion
+            .padding(5.dp)
+            .padding(innerPadding)
+    ) {
+        composable<Screen.PlaningRoute> {
+            HorizontalDivider()
+        }
+        composable<Screen.SpeakerRoute> {
+            HorizontalDivider()
+        }
+        composable<Screen.SpeechesRoute> {
+            HorizontalDivider()
+        }
+    }
+}

--- a/app/src/main/java/de/geosphere/speechplaning/ui/main/BottomBarComponent.kt
+++ b/app/src/main/java/de/geosphere/speechplaning/ui/main/BottomBarComponent.kt
@@ -1,0 +1,60 @@
+package de.geosphere.speechplaning.ui.main
+
+import androidx.compose.material3.Badge
+import androidx.compose.material3.BadgedBox
+import androidx.compose.material3.Icon
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.navigation.NavDestination
+import androidx.navigation.NavDestination.Companion.hierarchy
+import androidx.navigation.NavGraph.Companion.findStartDestination
+import androidx.navigation.NavHostController
+
+@Composable
+fun BottomBarComponent(
+    currentDestination: NavDestination?,
+    navController: NavHostController,
+    modifier: Modifier = Modifier,
+) {
+    NavigationBar(modifier = modifier) {
+        BottomNavigationItem.Companion.tabs.forEach { navItem ->
+            val isSelected = currentDestination?.hierarchy?.any {
+                it.route == navItem.route::class.qualifiedName
+            } == true
+            NavigationBarItem(
+                selected = isSelected,
+                onClick = {
+                    navController.navigate(navItem.route) {
+                        popUpTo(navController.graph.findStartDestination().id) {
+                            saveState = true
+                        }
+                        launchSingleTop = true
+                        restoreState = true
+                    }
+                },
+                label = { Text(navItem.label) },
+                icon = {
+                    BadgedBox(
+                        badge = {
+                            if (navItem.badgeCount != null) {
+                                Badge {
+                                    Text(text = navItem.badgeCount.toString())
+                                }
+                            } else if (navItem.hasNews) {
+                                Badge()
+                            }
+                        }
+                    ) {
+                        Icon(
+                            imageVector = if (isSelected) navItem.selectedIcon else navItem.unselectedIcon,
+                            contentDescription = navItem.label
+                        )
+                    }
+                }
+            )
+        }
+    }
+}

--- a/app/src/main/java/de/geosphere/speechplaning/ui/main/BottomNavigationItem.kt
+++ b/app/src/main/java/de/geosphere/speechplaning/ui/main/BottomNavigationItem.kt
@@ -1,0 +1,47 @@
+package de.geosphere.speechplaning.ui.main
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ListAlt
+import androidx.compose.material.icons.automirrored.outlined.ListAlt
+import androidx.compose.material.icons.filled.CalendarMonth
+import androidx.compose.material.icons.filled.FolderShared
+import androidx.compose.material.icons.outlined.CalendarMonth
+import androidx.compose.material.icons.outlined.FolderShared
+import androidx.compose.ui.graphics.vector.ImageVector
+import de.geosphere.speechplaning.ui.navigation.Screen
+
+data class BottomNavigationItem(
+    val label: String,
+    val selectedIcon: ImageVector,
+    val unselectedIcon: ImageVector,
+    val hasNews: Boolean,
+    val route: Screen,
+    val badgeCount: Int? = null,
+) {
+    companion object {
+        val tabs = listOf(
+            BottomNavigationItem(
+                label = "Plan",
+                selectedIcon = Icons.Filled.CalendarMonth,
+                unselectedIcon = Icons.Outlined.CalendarMonth,
+                route = Screen.PlaningRoute,
+                hasNews = true,
+            ),
+            BottomNavigationItem(
+                label = "Speakers",
+                selectedIcon = Icons.Filled.FolderShared,
+                unselectedIcon = Icons.Outlined.FolderShared,
+                route = Screen.SpeakerRoute,
+                hasNews = false,
+            ),
+            BottomNavigationItem(
+                label = "Speeches",
+                selectedIcon = Icons.AutoMirrored.Filled.ListAlt,
+                unselectedIcon = Icons.AutoMirrored.Outlined.ListAlt,
+                hasNews = false,
+                route = Screen.SpeechesRoute,
+                badgeCount = 45
+            ),
+        )
+    }
+}

--- a/app/src/main/java/de/geosphere/speechplaning/ui/main/MainScreenComponent.kt
+++ b/app/src/main/java/de/geosphere/speechplaning/ui/main/MainScreenComponent.kt
@@ -1,0 +1,36 @@
+package de.geosphere.speechplaning.ui.main
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.rememberTopAppBarState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
+import de.geosphere.speechplaning.ui.theme.SpeechPlaningTheme
+
+@Composable
+@OptIn(ExperimentalMaterial3Api::class)
+fun MainScreenComponent() {
+    val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
+    val navController = rememberNavController()
+
+    val navBackStackEntry by navController.currentBackStackEntryAsState()
+    val currentDestination = navBackStackEntry?.destination
+
+    SpeechPlaningTheme {
+        Scaffold(
+            topBar = {
+                TopBarComponent(scrollBehavior)
+            },
+            content = { innerPadding ->
+                AppNavHostComponent(navController, innerPadding)
+            },
+
+            bottomBar = {
+                BottomBarComponent(currentDestination = currentDestination, navController = navController)
+            },
+        )
+    }
+}

--- a/app/src/main/java/de/geosphere/speechplaning/ui/main/TopBarComponent.kt
+++ b/app/src/main/java/de/geosphere/speechplaning/ui/main/TopBarComponent.kt
@@ -1,0 +1,41 @@
+package de.geosphere.speechplaning.ui.main
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.TopAppBarScrollBehavior
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.style.TextOverflow
+
+@Composable
+@OptIn(ExperimentalMaterial3Api::class)
+fun TopBarComponent(scrollBehavior: TopAppBarScrollBehavior) {
+    CenterAlignedTopAppBar(
+        colors = TopAppBarDefaults.centerAlignedTopAppBarColors(
+            containerColor = MaterialTheme.colorScheme.primaryContainer,
+            titleContentColor = MaterialTheme.colorScheme.primary,
+        ),
+        title = {
+            Text(
+                "Centered Top App Bar",
+                maxLines = 1,
+                overflow = TextOverflow.Companion.Ellipsis
+            )
+        },
+        actions = {
+            IconButton(onClick = { /* do something */ }) {
+                Icon(
+                    imageVector = Icons.Filled.Menu,
+                    contentDescription = "Localized description"
+                )
+            }
+        },
+        scrollBehavior = scrollBehavior,
+    )
+}

--- a/app/src/main/java/de/geosphere/speechplaning/ui/navigation/Screen.kt
+++ b/app/src/main/java/de/geosphere/speechplaning/ui/navigation/Screen.kt
@@ -1,0 +1,15 @@
+package de.geosphere.speechplaning.ui.navigation
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+sealed class Screen {
+    @Serializable
+    data object SpeakerRoute : Screen()
+
+    @Serializable
+    data object PlaningRoute : Screen()
+
+    @Serializable
+    data object SpeechesRoute : Screen()
+}

--- a/app/src/test/java/de/geosphere/speechplaning/ui/main/BottomNavigationItemTest.kt
+++ b/app/src/test/java/de/geosphere/speechplaning/ui/main/BottomNavigationItemTest.kt
@@ -1,0 +1,79 @@
+package de.geosphere.speechplaning.ui.main
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ListAlt
+import androidx.compose.material.icons.filled.CalendarMonth
+import androidx.compose.material.icons.filled.FolderShared
+import de.geosphere.speechplaning.ui.navigation.Screen
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class BottomNavigationItemTest {
+
+    @Test
+    fun `test BottomNavigationItem creation and properties`() {
+        val testItem = BottomNavigationItem(
+            label = "Test",
+            selectedIcon = Icons.Default.CalendarMonth,
+            unselectedIcon = Icons.Default.CalendarMonth,
+            hasNews = true,
+            route = Screen.PlaningRoute,
+            badgeCount = 5
+        )
+
+        assertEquals("Test", testItem.label)
+        assertEquals(Icons.Default.CalendarMonth, testItem.selectedIcon)
+        assertEquals(Icons.Default.CalendarMonth, testItem.unselectedIcon)
+        assertEquals(true, testItem.hasNews)
+        assertEquals(Screen.PlaningRoute, testItem.route)
+        assertEquals(5, testItem.badgeCount)
+    }
+
+    @Test
+    fun `test companion object tabs list`() {
+        val tabs = BottomNavigationItem.tabs
+        assertEquals(3, tabs.size)
+
+        // Test Plan tab
+        val planTab = tabs[0]
+        assertEquals("Plan", planTab.label)
+        assertEquals(Icons.Filled.CalendarMonth, planTab.selectedIcon)
+        assertEquals(Screen.PlaningRoute, planTab.route)
+        assertEquals(true, planTab.hasNews)
+        assertNull(planTab.badgeCount)
+
+
+        // Test Speakers tab
+        val speakersTab = tabs[1]
+        assertEquals("Speakers", speakersTab.label)
+        assertEquals(Icons.Filled.FolderShared, speakersTab.selectedIcon)
+        assertEquals(Screen.SpeakerRoute, speakersTab.route)
+        assertEquals(false, speakersTab.hasNews)
+        assertNull(speakersTab.badgeCount)
+
+        // Test Speeches tab
+        val speechesTab = tabs[2]
+        assertEquals("Speeches", speechesTab.label)
+        assertEquals(Icons.AutoMirrored.Filled.ListAlt, speechesTab.selectedIcon)
+        assertEquals(Screen.SpeechesRoute, speechesTab.route)
+        assertEquals(false, speechesTab.hasNews)
+        assertEquals(45, speechesTab.badgeCount)
+    }
+
+    @Test
+    fun `test data class copy method`() {
+        val originalItem = BottomNavigationItem(
+            label = "Original",
+            selectedIcon = Icons.Default.CalendarMonth,
+            unselectedIcon = Icons.Default.CalendarMonth,
+            hasNews = false,
+            route = Screen.SpeakerRoute
+        )
+        val copiedItem = originalItem.copy(label = "Copied")
+
+        assertEquals("Copied", copiedItem.label)
+        assertEquals(originalItem.selectedIcon, copiedItem.selectedIcon)
+        assertEquals(originalItem.route, copiedItem.route)
+    }
+}

--- a/config/jacoco/jacoco_class_exclusions.txt
+++ b/config/jacoco/jacoco_class_exclusions.txt
@@ -14,6 +14,7 @@ android/**/*.*
 **/*_Impl.class
 **/*_HiltModules*.*
 **/*Composable*.class
+**/*Component*.class
 de/geosphere/speechplaning/data/model/**/*.class
 de/geosphere/speechplaning/data/services/**/*.class
 de/geosphere/speechplaning/data/database/**/*.class
@@ -25,5 +26,4 @@ de/geosphere/speechplaning/mockup/**/*.class
 **/*Activity*.class
 **/*Fragment*.class
 **/*Application*.class
-de/geosphere/speechplaning/Screen*.class
-de/geosphere/speechplaning/BottomNavigationItem*.class
+de/geosphere/speechplaning/**/Screen*.class

--- a/config/sonar/coverage_exclusions.txt
+++ b/config/sonar/coverage_exclusions.txt
@@ -3,3 +3,7 @@
 **/app/src/main/java/de/geosphere/speechplaning/mockup/**/*.kt
 **/app/**/build.gradle.kts
 **/app/**/MainActivity.kt
+**/app/**/*Component.kt
+**/app/**/*Screen.kt
+**/app/**/*Composable.kt
+


### PR DESCRIPTION
…to composable components

feat: add dummy DB connection builder
Refactor the `MainActivity` by extracting UI components into separate, reusable composables:
- `MainScreen`: The main scaffold and theme wrapper.
- `AppNavHost`: The navigation host for different screens.
- `TopBarComponents`: The top app bar.
- `BottomBarComponents`: The bottom navigation bar.
- `BottomNavigationItem`: Data class defining bottom navigation tabs.
- `Screen`: Sealed class for navigation routes.

A new `BuildDummyDBConnection` class is introduced to populate the database with mock data. This is now injected and called from `MainActivity` to separate concerns. Dependency injection in `ApplicationModule` is updated to provide this new class.